### PR TITLE
Availability set with fault & update domain count

### DIFF
--- a/9-app-deploy/main.tf
+++ b/9-app-deploy/main.tf
@@ -91,6 +91,8 @@ resource "azurerm_availability_set" "app" {
   location            = azurerm_resource_group.app.location
   resource_group_name = azurerm_resource_group.app.name
   managed             = true
+  platform_fault_domain_count  = 2
+  platform_update_domain_count = 2
 
   tags = {
     environment = terraform.workspace


### PR DESCRIPTION
I have added count for fault domain and update domain; otherwise, I am getting the below error

│ Error: compute.AvailabilitySetsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidParameter" Message="The specified fault domain count 3 must fall in the range 1 to 2." Target="platformFaultDomainCount"
│
│   with azurerm_availability_set.app,
│   on main.tf line 99, in resource "azurerm_availability_set" "app":
│   99: resource "azurerm_availability_set" "app" {